### PR TITLE
Fix usage of `RemoteData` in arguments

### DIFF
--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -407,7 +407,7 @@ class ShellJob(CalcJob):
                 self.write_folder_data(node, dirpath, filename)
                 argument_interpolated = argument.format(**{placeholder: filename or placeholder})
             elif isinstance(node, RemoteData):
-                self.handle_remote_data(node)
+                argument_interpolated = argument.format(**{placeholder: node.get_remote_path()})
             else:
                 argument_interpolated = argument.format(**{placeholder: str(node.value)})
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -140,12 +140,13 @@ def test_nodes_remote_data(tmp_path, aiida_localhost, use_symlinks):
     (dirpath_sub_filled / 'file_b.txt').write_text('content b')
 
     # Create a ``RemoteData`` node of the ``archive`` directory which should contain only the ``archive.zip`` file.
+    remote_zip = RemoteData(remote_path=str(dirpath_archive / 'archive'), computer=aiida_localhost)
     remote_data = RemoteData(remote_path=str(dirpath_archive), computer=aiida_localhost)
 
     results, node = launch_shell_job(
         'unzip',
-        arguments=['archive.zip'],
-        nodes={'remote': remote_data},
+        arguments=['{remote_zip}'],
+        nodes={'remote_zip': remote_zip, 'remote': remote_data},
         outputs=['file_a.txt'],
         metadata={
             'options': {'use_symlinks': use_symlinks},


### PR DESCRIPTION
The tests did not cover the usage of `RemoteData` in the arguments which did not cover the bug that `self.handle_remote_data` does not exist. We translate the node by passing the path to the arguments.